### PR TITLE
Add knowledge collection trigger workflow

### DIFF
--- a/.github/workflows/trigger-knowledge-collection.yml
+++ b/.github/workflows/trigger-knowledge-collection.yml
@@ -1,0 +1,38 @@
+name: Trigger Knowledge Collection
+
+# このワークフローは各リポジトリに配置し、PRマージ時にknowledge-repoへ通知します
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify-knowledge-repo:
+    # PRがマージされた場合のみ実行
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send repository dispatch to knowledge-repo
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          # knowledge-repoのリポジトリ情報を指定
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          repository: sk8metalme/review-dojo-knowledge
+          event-type: pr-merged
+          client-payload: |
+            {
+              "pr_url": "${{ github.event.pull_request.html_url }}",
+              "repo_owner": "${{ github.repository_owner }}",
+              "repo_name": "${{ github.event.repository.name }}",
+              "pr_number": "${{ github.event.pull_request.number }}",
+              "pr_title": "${{ github.event.pull_request.title }}",
+              "merged_by": "${{ github.event.pull_request.merged_by.login }}",
+              "merged_at": "${{ github.event.pull_request.merged_at }}"
+            }
+
+      - name: Log dispatch
+        run: |
+          echo "Dispatched knowledge collection for PR #${{ github.event.pull_request.number }}"
+          echo "PR: ${{ github.event.pull_request.html_url }}"
+          echo "Merged by: ${{ github.event.pull_request.merged_by.login }}"


### PR DESCRIPTION
## 概要
PRマージ時にレビュー知見を自動収集するワークフローを追加します。

## 変更内容
- `.github/workflows/trigger-knowledge-collection.yml` を追加

## 必要な設定
このワークフローを有効にするには、以下のシークレット設定が必要です：

1. Settings → Secrets and variables → Actions
2. 「New repository secret」をクリック
3. 名前: `ORG_GITHUB_TOKEN`
4. 値: 適切な権限を持つPersonal Access Token（repo, workflow スコープ）

---
Generated by distribute-workflow.sh